### PR TITLE
BREAKING: Use Puppet data types for all parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # puppet-module-fail2ban
 
+[![Puppet Forge](http://img.shields.io/puppetforge/v/treydock/fail2ban.svg)](https://forge.puppetlabs.com/treydock/fail2ban)
 [![Build Status](https://travis-ci.org/treydock/puppet-module-fail2ban.png)](https://travis-ci.org/treydock/puppet-module-fail2ban)
 
 ####Table of Contents
@@ -14,13 +15,24 @@
 
 ## Overview
 
-
+This module manages Fail2ban.
 
 ## Usage
 
 ### fail2ban
 
-    class { 'fail2ban': }
+Install and configure fail2ban with SSH jail.
+
+    class { 'fail2ban':
+      jails => ['sshd'],
+    }
+
+Configure fail2ban to not ban a local subnet
+
+    class { 'fail2ban':
+      jails            => ['sshd'],
+      default_ignoreip => ['10.0.0.0/8'],
+    }
 
 ## Reference
 
@@ -41,13 +53,80 @@
 
 #### fail2ban
 
-#####`foo`
+##### ensure
+
+Determines presence of fail2ban. Valid values are `present` and `absent`, default is `present`.
+
+##### package_ensure
+
+The ensure property of fail2ban package. Default is `present`.
+
+##### package_name
+
+The fail2ban package name. Default is OS dependent.
+
+##### manage_repo
+
+Boolean that sets if fail2ban repo is managed. For EL systems this enables management of EPEL repo.  Default is `true`
+
+##### service_name
+
+fail2ban service name. Default is OS dependent.
+
+##### service_ensure
+
+fail2ban service ensure property. Default is `running`.
+
+##### service_enable
+
+fail2ban service enable property. Default is `true`.
+
+##### service_hasstatus
+
+fail2ban service hasstatus property. Default is OS dependent.
+
+##### service_hasrestart
+
+fail2ban service hasrestart property. Default is OS dependent.
+
+##### config_path
+
+Path to fail2ban.local. Default is OS dependent.
+
+##### jail\_config_path
+
+Path to jail.local. Default is OS dependent.
+
+##### default_ignoreip
+
+Global ignoreip value. Default is `['127.0.0.1/8']`
+
+##### default_bantime
+
+Global bantime value. Default is `600`.
+
+##### default_findtime
+
+Global findtime value. Default is `600`.
+
+##### default_maxretry
+
+Global maxretry value. Default is `5`
+
+##### logtarget
+
+Location of logtarget. Default is OS dependent.
+
+##### jails
+
+Array or Hash of jails. Value is passed to `fail2ban::jail` defined type. Default is `undef`.
 
 ## Limitations
 
 This module has been tested on:
 
-* CentOS 6 x86_64
+* CentOS/RedHat 6 x86_64
+* CentOS/RedHat 7 x86_64
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Global maxretry value. Default is `5`
 
 ##### logtarget
 
-Location of logtarget. Default is OS dependent.
+Location of logtarget. Accepts `SYSLOG`, `STDOUT`, `STDERR` or a file path.  Default is `/var/log/fail2ban.log`.
 
 ##### jails
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,22 +1,24 @@
 # See README.md for more details.
 class fail2ban (
-  $ensure               = 'present',
-  $package_ensure       = 'present',
-  $package_name         = $fail2ban::params::package_name,
-  Boolean $manage_repo  = true,
-  $service_name         = $fail2ban::params::service_name,
-  $service_ensure       = 'running',
-  $service_enable       = true,
-  $service_hasstatus    = $fail2ban::params::service_hasstatus,
-  $service_hasrestart   = $fail2ban::params::service_hasrestart,
-  $config_path          = $fail2ban::params::config_path,
-  $jail_config_path     = $fail2ban::params::jail_config_path,
-  $default_ignoreip     = ['127.0.0.1/8'],
-  $default_bantime      = '600',
-  $default_findtime     = '600',
-  $default_maxretry     = '5',
-  $logtarget            = $fail2ban::params::logtarget,
-  $jails                = undef,
+  Enum['present', 'absent'] $ensure       = 'present',
+  String $package_ensure                  = 'present',
+  String $package_name                    = $fail2ban::params::package_name,
+  Boolean $manage_repo                    = true,
+  String $service_name                    = $fail2ban::params::service_name,
+  String $service_ensure                  = 'running',
+  Boolean $service_enable                 = true,
+  Boolean $service_hasstatus              = $fail2ban::params::service_hasstatus,
+  Boolean $service_hasrestart             = $fail2ban::params::service_hasrestart,
+  Stdlib::Absolutepath $config_path       = $fail2ban::params::config_path,
+  Stdlib::Absolutepath $jail_config_path  = $fail2ban::params::jail_config_path,
+  Array[Stdlib::Compat::Ip_address]
+    $default_ignoreip                     = ['127.0.0.1/8'],
+  Integer $default_bantime                = 600,
+  Integer $default_findtime               = 600,
+  Integer $default_maxretry               = 5,
+  Variant[Enum['SYSLOG','STDOUT','STDERR'],Stdlib::Absolutepath]
+    $logtarget                            = $fail2ban::params::logtarget,
+  Optional[Variant[Array, Hash]] $jails   = undef,
 ) inherits fail2ban::params {
 
   case $ensure {
@@ -55,13 +57,10 @@ class fail2ban (
 
 
   if $jails and $ensure == 'present' {
-    if is_array($jails) {
+    if $jails =~ Array {
       fail2ban::jail { $jails: }
-    } elsif is_hash($jails) {
+    } elsif $jails =~ Hash {
       create_resources('fail2ban::jail', $jails)
-    } else {
-      $_type = type3x($jails)
-      fail("Module ${module_name}: jails must be an array or a hash, ${_type} given.")
     }
   }
 

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -1,20 +1,13 @@
 #
 define fail2ban::jail (
-  $ensure = 'present',
+  Enum['present', 'absent'] $ensure = 'present',
 ) {
 
   include fail2ban
 
-  case $ensure {
-    'present': {
-      $_enabled = true
-    }
-    'absent': {
-      $_enabled = false
-    }
-    default: {
-      fail("Defined type fail2ban::jail: ensure only supports 'present' or 'absent', ${ensure} given.")
-    }
+  $_enabled = $ensure ? {
+    'present' => true,
+    'absent'  => false,
   }
 
   fail2ban_jail_config { "${name}/enabled": value => $_enabled }

--- a/spec/shared_examples/config.rb
+++ b/spec/shared_examples/config.rb
@@ -27,6 +27,7 @@ shared_context "fail2ban::config" do |facts|
     })
   end
 
+  it { is_expected.to contain_fail2ban_config('Definition/logtarget').with_value('/var/log/fail2ban.log') }
   it { is_expected.to contain_fail2ban_jail_config('DEFAULT/ignoreip').with_value('127.0.0.1/8') }
   it { is_expected.to contain_fail2ban_jail_config('DEFAULT/bantime').with_value('600') }
   it { is_expected.to contain_fail2ban_jail_config('DEFAULT/findtime').with_value('600') }


### PR DESCRIPTION
Previous integer values that accepted strings no longer accept strings, must be integers.  All other parameters remain backwards compatible.